### PR TITLE
Fix case sensitivity issue with table name

### DIFF
--- a/HighestTraffic/Plugin.cs
+++ b/HighestTraffic/Plugin.cs
@@ -76,7 +76,7 @@ namespace HighestTraffic
 
 			//last entry
 			using (var reader =
-				_database.QueryReader("SELECT MaxPlayers FROM traffic WHERE ID = (SELECT Max(ID) FROM traffic)"))
+				_database.QueryReader("SELECT MaxPlayers FROM Traffic WHERE ID = (SELECT Max(ID) FROM Traffic)"))
 			{
 				if (reader.Read())
 				{


### PR DESCRIPTION
Because the "traffic" identifier is not the same as "Traffic," the plugin will fail on unix operating systems connecting to a local database, or on Windows systems connecting to a remote MySQL database.

> In MySQL, databases correspond to directories within the data directory. Each table within a database corresponds to at least one file within the database directory (and possibly more, depending on the storage engine). Triggers also correspond to files. Consequently, the case sensitivity of the underlying operating system plays a part in the case sensitivity of database, table, and trigger names.

http://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html